### PR TITLE
Move to Multi-Arch images

### DIFF
--- a/scripts/buster_deps.sh
+++ b/scripts/buster_deps.sh
@@ -5,13 +5,14 @@ dpkg --add-architecture i386
 
 apt-get update -qq
 apt-get upgrade -yqq
-apt-get install git uncrustify python{,3}-distutils-extra python{,3}-dev build-essential libffi-dev swig autoconf libtool pkg-config lib32z1 openjdk-11-jdk ca-certificates-java unzip curl libc6:i386 libc6-dev:i386 libncurses5:i386 libstdc++6:i386 lib32z1 virtualenv python{,3}-setuptools apt-transport-https -yqq
-update-java-alternatives -s java-1.11.0-openjdk-amd64
+apt-get install git uncrustify python{,3}-distutils-extra python{,3}-dev build-essential libffi-dev swig autoconf libtool pkg-config libz1 ca-certificates-java unzip curl libc6:i386 libc6-dev:i386 libncurses5:i386 libstdc++6:i386 virtualenv python{,3}-setuptools apt-transport-https -yqq
 
 git clone https://github.com/juj/emsdk.git
 cd emsdk
-./emsdk install 2.0.9
-./emsdk activate 2.0.9
+#./emsdk install latest
+#./emsdk activate latest
+EMSDK_ARCH=x86_64 ./emsdk install 2.0.9
+EMSDK_ARCH=x86_64 ./emsdk activate 2.0.9
 source ./emsdk_env.sh
 
 apt-get remove --purge curl unzip apt-transport-https -yqq


### PR DESCRIPTION
Changes:
- replace lib32z1 with libz1
- remove java
- specify EMSDK_ARCH=x86_64

With this I am getting this error
```
checking for gcc... /emsdk/upstream/emscripten/emcc
checking whether the C compiler works... no
configure: error: in `/libwally-core':
configure: error: C compiler cannot create executables
```

I suspect `EMSDK_ARCH=x86_64` to not work.

We could use latest emsdk but that means using latest libwally.
```
./emsdk install latest
./emsdk activate latest
```

@tiero @altafan What do you think?


